### PR TITLE
Added `pip install ccal` to set environment

### DIFF
--- a/set_environment.md
+++ b/set_environment.md
@@ -65,6 +65,8 @@ conda install --channel conda-forge --yes nodejs yarn
 
 pip install genotype_to_phenotype
 
+pip install ccal
+
 conda update --all --yes
 ```
 


### PR DESCRIPTION
Its true that the project.jsons of CCAL workflows include ccal as one of the things that will be installed in the environment folder in the given project. Hoever we often work on projects using our global environment, which means we need CCAL installed in global/root conda environment.